### PR TITLE
fix typo in cube metadata generation

### DIFF
--- a/xcube_sh/chunkstore.py
+++ b/xcube_sh/chunkstore.py
@@ -140,7 +140,7 @@ class RemoteStore(MutableMapping, metaclass=ABCMeta):
                                 }, {
                                     "_ARRAY_DIMENSIONS": ['lat'],
                                     "units": "decimal_degrees",
-                                    "long_name": "longitude",
+                                    "long_name": "latitude",
                                     "standard_name": "latitude",
                                 })
         else:


### PR DESCRIPTION
Catches metadata bug. Latitude `long_name` should be latitude