### PR TITLE
configured cube config to accept None as time parameters.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Changes in 0.6.3 (in development)
-
+* Cube configuration parameter `time_range` accepts `None` as values. If `time_range=[None,'2021-02-01']` is used, 
+  then '1970-01-01' is used as the `start_time` default value. If `time_range=['2021-02-01', None]` is used, then the 
+  default date for `end_time` is the current date. 
 * Changed the cube configuration parameter `crs` (spatial coordinate reference system)
   so users can pass `"WGS84"`, `"CRS84"` or `"EPSG:{code}"`, where `{code}` is an EPSG 
   code e.g. `"EPSG:4326"`. The old URI notation is still supported, e.g.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## Changes in 0.6.3 (in development)
-* Cube configuration parameter `time_range` accepts `None` as values. If `time_range=[None,'2021-02-01']` is used, 
-  then '1970-01-01' is used as the `start_time` default value. If `time_range=['2021-02-01', None]` is used, then the 
-  default date for `end_time` is the current date. 
+* Cube configuration parameter `time_range` accepts `None` as start and end date values. For example,
+  if `time_range=[None,'2021-02-01']` is provided, then the start date is '1970-01-01'; 
+  if `time_range=['2021-02-01', None]` is provided, then the end date is the current date (today). 
 * Changed the cube configuration parameter `crs` (spatial coordinate reference system)
   so users can pass `"WGS84"`, `"CRS84"` or `"EPSG:{code}"`, where `{code}` is an EPSG 
   code e.g. `"EPSG:4326"`. The old URI notation is still supported, e.g.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 
 import unittest
+import numpy as np
 
 import pandas as pd
 
@@ -77,6 +78,22 @@ class CubeConfigTest(unittest.TestCase):
         self.assertAlmostEqual(54.53864, y2, places=4)
         self.assertEqual(w, round((x2 - x1) / spatial_res))
         self.assertEqual(h, round((y2 - y1) / spatial_res))
+
+    def test_time_none(self):
+        config = CubeConfig.from_dict(dict(dataset_name='S2L2A',
+                                           band_names=('B01', 'B02', 'B03'),
+                                           bbox=(10.11, 54.17, 10.14, 54.19),
+                                           spatial_res=0.00001,
+                                           time_range=('2019-01-01', None)))
+        self.assertEqual(np.datetime64('today', 's'), np.datetime64(config.time_range[1], 's'))
+
+        config = CubeConfig.from_dict(dict(dataset_name='S2L2A',
+                                           band_names=('B01', 'B02', 'B03'),
+                                           bbox=(10.11, 54.17, 10.14, 54.19),
+                                           spatial_res=0.00001,
+                                           time_range=(None, None)))
+        self.assertEqual(np.datetime64('today', 's'), np.datetime64(config.time_range[1], 's'))
+        self.assertEqual(np.datetime64('1970-01-01', 's'), np.datetime64(config.time_range[0], 's'))
 
     def test_time_deltas(self):
         config = CubeConfig.from_dict(dict(dataset_name='S2L2A',

--- a/test/test_cube.py
+++ b/test/test_cube.py
@@ -21,6 +21,7 @@
 
 import unittest
 
+import numpy as np
 import xarray as xr
 
 from test.test_sentinelhub import HAS_SH_CREDENTIALS
@@ -36,6 +37,20 @@ cube_config = CubeConfig(dataset_name='S2L1C',
                          time_range=('2018-05-14', '2018-07-31'),
                          time_tolerance='30M')
 
+cube_config_t1_none = CubeConfig(dataset_name='S2L1C',
+                         band_names=['B04'],
+                         bbox=(10.00, 54.27, 11.00, 54.60),
+                         spatial_res=0.00018,
+                         time_range=('2021-01-01', None),
+                         time_period='1D')
+
+cube_config_t_none = CubeConfig(dataset_name='S2L1C',
+                         band_names=['B04'],
+                         bbox=(10.00, 54.27, 11.00, 54.60),
+                         spatial_res=0.00018,
+                         time_range=(None,'2021-02-18'),
+                         time_tolerance='30M')
+
 
 @unittest.skipUnless(HAS_SH_CREDENTIALS, REQUIRE_SH_CREDENTIALS)
 class CubeTest(unittest.TestCase):
@@ -43,6 +58,16 @@ class CubeTest(unittest.TestCase):
         cube = open_cube(cube_config=cube_config)
         self.assertIsInstance(cube, xr.Dataset)
 
+    def test_time_max_none(self):
+        cube = open_cube(cube_config=cube_config_t1_none)
+        self.assertIsInstance(cube, xr.Dataset)
+        self.assertEqual(np.datetime64('today', 'D'), np.datetime64(cube.time.values[-1], 'D'))        # self.assertEqual()
+
+    def test_time_none(self):
+        cube = open_cube(cube_config=cube_config_t_none)
+        self.assertIsInstance(cube, xr.Dataset)
+        self.assertEqual(np.datetime64('2021-02-16'), np.datetime64(cube.time.values[-1], 'D'))        # self.assertEqual()
+        self.assertEqual(np.datetime64('2015-06-27'), np.datetime64(cube.time.values[0], 'D'))        # self.assertEqual()
 
 class CubeTest2(unittest.TestCase):
     def test_open_cube_with_illegal_kwargs(self):

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -106,9 +106,9 @@ class SentinelHubDataStoreTest(unittest.TestCase):
         self.assertIn('time_range', schema.properties)
         self.assertEqual(
             {
-                'type': 'array',
-                'items': [{'type': 'string', 'format': 'date', 'minDate': '2016-11-01'},
-                          {'type': 'string', 'format': 'date', 'minDate': '2016-11-01'}],
+                'type':  ['array', 'null'],
+                'items': [{'type': ['string', 'null'], 'format': 'date', 'minDate': '2016-11-01'},
+                          {'type': ['string', 'null'], 'format': 'date', 'minDate': '2016-11-01'}],
             },
             schema.properties['time_range'].to_dict())
         self.assertIn('time_period', schema.properties)

--- a/xcube_sh/config.py
+++ b/xcube_sh/config.py
@@ -21,11 +21,12 @@
 
 import math
 import warnings
+from datetime import datetime
 from typing import Tuple, Union, Optional, Sequence, Dict, Any
 
 import pandas as pd
-
 from xcube.util.assertions import assert_given, assert_condition
+
 from .constants import CRS_ID_TO_URI
 from .constants import CRS_URI_TO_ID
 from .constants import DEFAULT_CRS
@@ -99,6 +100,16 @@ class CubeConfig:
         assert_given(bbox, 'bbox')
 
         assert_given(time_range, 'time_range')
+
+        if time_range[1] is None:
+            time_list = list(time_range)
+            time_list[1] = datetime.now().strftime("%Y-%m-%d")
+            time_range = tuple(time_list)
+
+        if time_range[0] is None:
+            time_list = list(time_range)
+            time_list[0] = '1970-01-01'
+            time_range = tuple(time_list)
 
         time_period = time_period or None
         time_tolerance = time_tolerance or None

--- a/xcube_sh/config.py
+++ b/xcube_sh/config.py
@@ -101,16 +101,10 @@ class CubeConfig:
 
         assert_given(time_range, 'time_range')
 
-        if time_range[1] is None:
-            time_list = list(time_range)
-            time_list[1] = datetime.now().strftime("%Y-%m-%d")
-            time_range = tuple(time_list)
-
-        if time_range[0] is None:
-            time_list = list(time_range)
-            time_list[0] = '1970-01-01'
-            time_range = tuple(time_list)
-
+        start_date, end_date = time_range if time_range is not None else (None, None)
+        start_date = start_date if start_date is not None else '1970-01-01' 
+        end_date = end_date if end_date is not None else datetime.now().strftime("%Y-%m-%d")
+        time_range = start_date, end_date
         time_period = time_period or None
         time_tolerance = time_tolerance or None
 

--- a/xcube_sh/store.py
+++ b/xcube_sh/store.py
@@ -191,7 +191,7 @@ class SentinelHubDataOpener(DataOpener):
                                         JsonNumberSchema(),
                                         JsonNumberSchema())),
             spatial_res=JsonNumberSchema(exclusive_minimum=0.0),
-            time_range=JsonDateSchema.new_range(min_date=min_date, max_date=max_date),
+            time_range=JsonDateSchema.new_range(min_date=min_date, max_date=max_date, nullable=True),
             # TODO: add pattern
             time_period=JsonStringSchema(default='1D', nullable=True,
                                          enum=[None,


### PR DESCRIPTION
Cube configuration parameter `time_range` accepts `None` as values. If `time_range=[None,'2021-02-01']` is used, 
  then '1970-01-01' is used as the `start_time` default value. If `time_range=['2021-02-01', None]` is used, then the 
  default date for `end_time` is the current date. 