### PR TITLE
Adding Landsat-8 Collection 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## Changes in 0.8.0 (in development)
-* added ids for Collections Landsat-8 L1 and Landsat-8 L2 #53
+* Now supporting Landsat-8 Level-1 (`"LOTL1"`) and Level-2 (`"LOTL2"`) collections (#53, thanks @maximlamare for PR #54)
 * Now works for `bbox` coordinates using a CRS other than CRS84, WGS84, EPSG:4326. (#???)
 * Provided xcube data store framework interface compatibility with 
   breaking changes in xcube 0.8.0 (see https://github.com/dcs4cop/xcube/issues/420).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## Changes in 0.8.0 (in development)
-
+* added ids for Collections Landsat-8 L1 and Landsat-8 L2 #53
 * Now works for `bbox` coordinates using a CRS other than CRS84, WGS84, EPSG:4326. (#???)
 * Provided xcube data store framework interface compatibility with 
   breaking changes in xcube 0.8.0 (see https://github.com/dcs4cop/xcube/issues/420).

--- a/test/test_cube.py
+++ b/test/test_cube.py
@@ -60,6 +60,13 @@ cube_config_with_crs = CubeConfig(dataset_name='S2L1C',
                                   time_range=('2018-05-14', '2020-07-31'),
                                   time_tolerance='30M')
 
+cube_config_LOTL2 = CubeConfig(dataset_name='LOTL2',
+                         band_names=['B02', 'B03'],
+                         bbox= (-17.554176,14.640112,-17.387367,14.792487),
+                         spatial_res=0.000089,
+                         time_range=('2018-05-14', '2020-07-31'),
+                         time_tolerance='30M')
+
 
 @unittest.skipUnless(HAS_SH_CREDENTIALS, REQUIRE_SH_CREDENTIALS)
 class CubeTest(unittest.TestCase):
@@ -96,3 +103,11 @@ class CubeWithCredentialsTest(unittest.TestCase):
         self.assertEqual({'time': 320, 'y': 2048, 'x': 2048, 'bnds': 2}, cube.dims)
         self.assertEqual({'x', 'y', 'time', 'time_bnds'}, set(cube.coords))
         self.assertEqual({'B01'}, set(cube.data_vars))
+
+    @unittest.skipUnless(HAS_SH_CREDENTIALS, REQUIRE_SH_CREDENTIALS)
+    def test_open_cube_LOTL2(self):
+        cube = open_cube(cube_config_LOTL2, api_url="https://services-uswest2.sentinel-hub.com")
+        self.assertIsInstance(cube, xr.Dataset)
+        self.assertEqual({'time': 100, 'lat': 1912, 'lon': 2094, 'bnds': 2}, cube.dims)
+        self.assertEqual({'lat', 'lon', 'time', 'time_bnds'}, set(cube.coords))
+        self.assertEqual({'B02', 'B03'}, set(cube.data_vars))

--- a/test/test_cube.py
+++ b/test/test_cube.py
@@ -61,11 +61,11 @@ cube_config_with_crs = CubeConfig(dataset_name='S2L1C',
                                   time_tolerance='30M')
 
 cube_config_LOTL2 = CubeConfig(dataset_name='LOTL2',
-                         band_names=['B02', 'B03'],
-                         bbox= (-17.554176,14.640112,-17.387367,14.792487),
-                         spatial_res=0.000089,
-                         time_range=('2018-05-14', '2020-07-31'),
-                         time_tolerance='30M')
+                               band_names=['B02', 'B03'],
+                               bbox= (-17.554176,14.640112,-17.387367,14.792487),
+                               spatial_res=0.000089,
+                               time_range=('2018-05-14', '2020-07-31'),
+                               time_tolerance='30M')
 
 
 @unittest.skipUnless(HAS_SH_CREDENTIALS, REQUIRE_SH_CREDENTIALS)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -30,7 +30,7 @@ class SentinelHubMetadataTest(unittest.TestCase):
         md = SentinelHubMetadata()
 
         self.assertEqual(['S1GRD', 'S2L1C', 'S2L2A', 'S3OLCI', 'S3SLSTR', 'S5PL2',
-                          'L8L1C', 'DEM', 'MODIS', 'CUSTOM'], md.dataset_names)
+                          'L8L1C', 'LOTL1', 'LOTL2', 'DEM', 'MODIS', 'CUSTOM'], md.dataset_names)
 
     def test_dataset_band(self):
         md = SentinelHubMetadata()
@@ -59,6 +59,10 @@ class SentinelHubMetadataTest(unittest.TestCase):
                           'wavelength_b': 492.1},
                          md.dataset_band('S2L2A', 'B02'))
 
+        self.assertEqual(['B01', 'B02', 'B03', 'B04', 'B05', 'B06', 'B07', 'B08', 'B09', 'B10', 'B11', 'BQA',
+                          'QA_RADSAT', 'VAA', 'VZA', 'SAA', 'SZA'],
+                         md.dataset_band_names('LOTL1'))
+
     def test_wavelengths_numeric(self):
         self.assertEqual((0, 0), self._assert_all_wavelengths_numeric('S1GRD'))
         self.assertEqual((13, 13), self._assert_all_wavelengths_numeric('S2L1C'))
@@ -67,6 +71,8 @@ class SentinelHubMetadataTest(unittest.TestCase):
         self.assertEqual((11, 11), self._assert_all_wavelengths_numeric('S3SLSTR'))
         self.assertEqual((0, 0), self._assert_all_wavelengths_numeric('S5PL2'))
         self.assertEqual((12, 0), self._assert_all_wavelengths_numeric('L8L1C'))
+        self.assertEqual((17, 0), self._assert_all_wavelengths_numeric('LOTL1'))
+        self.assertEqual((19, 0), self._assert_all_wavelengths_numeric('LOTL2'))
         self.assertEqual((7, 7), self._assert_all_wavelengths_numeric('MODIS'))
 
     def _assert_all_wavelengths_numeric(self, ds_name: str) -> Tuple[int, int]:

--- a/xcube_sh/metadata.py
+++ b/xcube_sh/metadata.py
@@ -385,14 +385,14 @@ _SH_METADATA = dict(
             bands=LOTL1_BAND_METADATA,
             processing_level='L1C',
             request_period='1D',
-            collection_name='LOTL1',
+            collection_name='landsat-ot-l1',
         ),
         'LOTL2': dict(
             title='Landsat 8 - L2A',
             bands=LOTL2_BAND_METADATA,
             processing_level='L2A',
             request_period='1D',
-            collection_name='LOTL2',
+            collection_name='landsat-ot-l2',
         ),
         'DEM': dict(
             title='Mapzen DEM',


### PR DESCRIPTION
added ids for Collections Landsat-8 L1 and Landsat-8 L2 #53

Can be tested by: 

```
from xcube_sh.sentinelhub import SentinelHub
from xcube_sh.config import CubeConfig
from xcube_sh.cube import open_cube

SH = SentinelHub()
SH.api_url = ("https://services-uswest2.sentinel-hub.com")

dakar_bbox = [-17.554176,14.640112,-17.387367,14.792487]

cube_config = CubeConfig(dataset_name='LOTL1',
                         band_names=['B02', 'B03'],
                         bbox=dakar_bbox,
                         spatial_res=0.000089,
                         time_range=['2018-05-14', '2020-07-31'],
                         time_tolerance='30M')

cube = open_cube(cube_config,sentinel_hub=SH)
cube

```