### PR TITLE
Allow filtering observations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 ## Changes in 0.10.2 (in development)
 
+* A new parameter `extra_search_params` has been added the `CubeConfig` as 
+  well as to the data store's `open_data()` method. (#93)
+
+  The value of `extra_search_params` is a dictionary that defines 
+  additional search parameters when querying the individual observations 
+  (time slices) that will form the data cube.  
+  Examples for such parameters are the keys `"filter"`, `"filter-lang"`,
+  or ``"fields"``. More on this can be found in the 
+  [Sentinel Hub Catalog API documentation](https://docs.sentinel-hub.com/api/latest/api/catalog/).
+
+  Note that `extra_search_params` will be ignored if `time_period` is used
+  (i.e., given and not `None`).
+
 ## Changes in 0.10.1
 
 * Fixed problem with that some parameters that were listed as result from 

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -134,6 +134,7 @@ class SentinelHubDataStoreTest(unittest.TestCase):
         self.assertIn('upsampling', schema.properties)
         self.assertIn('downsampling', schema.properties)
         self.assertIn('mosaicking_order', schema.properties)
+        self.assertIn('extra_search_params', schema.properties)
 
         self.assertIn('time_range', schema.properties)
         self.assertEqual(

--- a/xcube_sh/chunkstore.py
+++ b/xcube_sh/chunkstore.py
@@ -598,7 +598,8 @@ class SentinelHubChunkStore(RemoteStore):
                 time_start.strftime(datetime_format),
                 time_end.strftime(datetime_format)
             ),
-            bad_request_ok=False
+            bad_request_ok=False,
+            **self._cube_config.extra_search_params
         )
         if not features:
             # Maybe the dataset has no data in given time_range
@@ -609,7 +610,8 @@ class SentinelHubChunkStore(RemoteStore):
                 collection_name=collection_name,
                 bbox=self._cube_config.bbox,
                 crs=self._cube_config.crs,
-                bad_request_ok=True
+                bad_request_ok=True,
+                **self._cube_config.extra_search_params
             )
             if not features:
                 # Still no results.

--- a/xcube_sh/store.py
+++ b/xcube_sh/store.py
@@ -126,7 +126,9 @@ class SentinelHubDataOpener(DataOpener):
         * ``collection_id: str``
             - An identifier used by Sentinel HUB to identify BYOC datasets.
         * ``four_d: bool``
-            - If True, variables will represented as fourth dimension.
+            - If True, variables will be represented as fourth dimension.
+        * ``extra_search_params: Dict[str, Any]``
+            - If True, variables will be represented as fourth dimension.
 
         In addition, all store parameters can be used, if the data
         opener is used on its own. See
@@ -179,6 +181,7 @@ class SentinelHubDataOpener(DataOpener):
                 'time_tolerance',
                 'collection_id',
                 'four_d',
+                'extra_search_params'
             )
         )
 
@@ -295,6 +298,7 @@ class SentinelHubDataOpener(DataOpener):
             ),
             collection_id=JsonStringSchema(),
             four_d=JsonBooleanSchema(default=False),
+            extra_search_params=JsonObjectSchema(additional_properties=True),
         )
         cache_params = dict(
             max_cache_size=JsonIntegerSchema(minimum=0),


### PR DESCRIPTION
A new parameter `extra_search_params` has been added the `CubeConfig` as well as to the data store's `open_data()` method.

The value of `extra_search_params` is a dictionary that defines additional search parameters when querying the individual observations (time slices) that will form the data cube. Examples for such parameters are the keys `"filter"`, `"filter-lang"`, or ``"fields"``. More on this can be found in the [Sentinel Hub Catalog API documentation](https://docs.sentinel-hub.com/api/latest/api/catalog/).

Note that `extra_search_params` will be ignored if `time_period` is used
(i.e., given and not `None`).

Closes #93.