### PR TITLE
Bands of cubes generated with four_d can not be opened

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## Changes in 0.10.3 (in development)
 
-* Bands from cubes generated with `four_d` parameter set to true can be opened. 
-  (#101)
+* Fixed a bug which caused that, when the `four_d` parameter was set to true
+  when opening a dataset, the data of the bands of the resulting cubes could 
+  not be accessed. (#101)
 
 ## Changes in 0.10.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changes in 0.10.3 (in development)
 
+* Bands from cubes generated with `four_d` parameter set to true can be opened. 
+  (#101)
+
 ## Changes in 0.10.2
 
 * Added support for Landsat-4,5 Level-2 (`"LTML2"`) 

--- a/test/request-multi-byod.json
+++ b/test/request-multi-byod.json
@@ -29,24 +29,12 @@
     "height": 305,
     "responses": [
       {
-        "identifier": "RED",
-        "format": {
-          "type": "image/tiff"
-        }
-      },
-      {
-        "identifier": "GREEN",
-        "format": {
-          "type": "image/tiff"
-        }
-      },
-      {
-        "identifier": "BLUE",
+        "identifier": "default",
         "format": {
           "type": "image/tiff"
         }
       }
     ]
   },
-  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: ['RED', 'GREEN', 'BLUE'],\n        output: [\n            {id: 'RED', bands: 1, sampleType: 'UINT8'},\n            {id: 'GREEN', bands: 1, sampleType: 'UINT8'},\n            {id: 'BLUE', bands: 1, sampleType: 'UINT8'},\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return {\n        RED: [sample.RED],\n        GREEN: [sample.GREEN],\n        BLUE: [sample.BLUE],\n    };\n}"
+  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: [{\n            bands: ['RED', 'GREEN', 'BLUE']\n        }],\n        output: [\n            {bands: 3, sampleType: 'UINT8'}\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return [sample.RED, sample.GREEN, sample.BLUE];\n}"
 }

--- a/test/request-multi.json
+++ b/test/request-multi.json
@@ -33,30 +33,12 @@
     "height": 512,
     "responses": [
       {
-        "identifier": "B02",
-        "format": {
-          "type": "image/tiff"
-        }
-      },
-      {
-        "identifier": "B03",
-        "format": {
-          "type": "image/tiff"
-        }
-      },
-      {
-        "identifier": "B04",
-        "format": {
-          "type": "image/tiff"
-        }
-      },
-      {
-        "identifier": "B08",
+        "identifier": "default",
         "format": {
           "type": "image/tiff"
         }
       }
     ]
   },
-  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: [{\n            bands: ['B02', 'B03', 'B04', 'B08'],\n            units: ['reflectance', 'reflectance', 'reflectance', 'reflectance'],\n        }],\n        output: [\n            {id: 'B02', bands: 1, sampleType: 'FLOAT32'},\n            {id: 'B03', bands: 1, sampleType: 'FLOAT32'},\n            {id: 'B04', bands: 1, sampleType: 'FLOAT32'},\n            {id: 'B08', bands: 1, sampleType: 'FLOAT32'},\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return {\n        B02: [sample.B02],\n        B03: [sample.B03],\n        B04: [sample.B04],\n        B08: [sample.B08],\n    };\n}"
+  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: [{\n            bands: ['B02', 'B03', 'B04', 'B08'],\n            units: ['reflectance', 'reflectance', 'reflectance', 'reflectance']\n        }],\n        output: [\n            {bands: 4, sampleType: 'FLOAT32'}\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return [sample.B02, sample.B03, sample.B04, sample.B08];\n}"
 }

--- a/test/request-single-byod.json
+++ b/test/request-single-byod.json
@@ -36,5 +36,5 @@
       }
     ]
   },
-  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: ['RED'],\n        output: [\n            {bands: 1, sampleType: 'UINT8'}\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return [sample.RED];\n}"
+  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: [{\n            bands: ['RED']\n        }],\n        output: [\n            {bands: 1, sampleType: 'UINT8'}\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return [sample.RED];\n}"
 }

--- a/test/request-single.json
+++ b/test/request-single.json
@@ -40,5 +40,5 @@
       }
     ]
   },
-  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: [{\n            bands: ['B02'],\n            units: ['reflectance'],\n        }],\n        output: [\n            {bands: 1, sampleType: 'FLOAT32'}\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return [sample.B02];\n}"
+  "evalscript": "//VERSION=3\nfunction setup() {\n    return {\n        input: [{\n            bands: ['B02'],\n            units: ['reflectance']\n        }],\n        output: [\n            {bands: 1, sampleType: 'FLOAT32'}\n        ]\n    };\n}\nfunction evaluatePixel(sample) {\n    return [sample.B02];\n}"
 }


### PR DESCRIPTION
Fixes #101 . The problem was that the store requests the mime-type application/octet-stream which it can decode. The requests for multiple bands however did not support this mime type, because it returned multiple (tiff) files. I therefore changed the request so that it returns a single tiff file with multiple bands.