### PR TITLE
Update appveyor.yml (mainly to fix CI on Ubuntu)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 
 image:
-  - Ubuntu2004
+  - Ubuntu2204
   - macos
 
 configuration: Release
@@ -15,20 +15,21 @@ for:
     only:
       - image: macos
   install:
-    - curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    - curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
     - mv bin/micromamba ./micromamba
 -
   matrix:
     only:
-      - image: Ubuntu2004
+      - image: Ubuntu2204
   install:
-    - wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+    - curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+    - mv bin/micromamba ./micromamba
 
 build_script:
   # Set up micromamba
   - ./micromamba shell init -s bash -p ~/micromamba
   - source ~/.bashrc
-  - source ~/.bash_profile
+  - source ~/.profile
   - hash -r
   - mkdir -p ~/micromamba/pkgs/
   - export MAMBA_ROOT_PREFIX=~/micromamba


### PR DESCRIPTION
- When setting up environment, source ~/.profile rather than the now non-existent ~/.bash_profile (fixes #105).

- Update Ubuntu image from ubuntu2004 to ubuntu2204.

- Update micromamba download URLs to current official recommendations (old URLs still work, but we don't know for how long this will continue to be the case).
