### PR TITLE
Add missing dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,15 @@ channels:
   - defaults
 
 dependencies:
-  - xcube >=0.10
+  - click
+  - numcodecs
+  - numpy
   - oauthlib >=3.0
+  - pandas
+  - psutil
+  - pyproj
+  - requests
   - requests-oauthlib >=1.3
+  - xarray
+  - xcube >=0.10
+  - zarr

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: xcube-sh
 
 channels:
   - conda-forge
-  - defaults
 
 dependencies:
   - click


### PR DESCRIPTION
Add missing directly imported dependencies to `environment.yml` (which fixes #110 ) and remove the unneeded `defaults` channel.